### PR TITLE
[add] Windows用のターミナル設定を追加

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -5,6 +5,14 @@
   },
   "terminal.integrated.defaultProfile.linux": "bash",
 
+  // Windows用のターミナル設定
+  "terminal.integrated.profiles.windows": {
+    "Git Bash": {
+      "path": "C:/Program Files/Git/bin/bash.exe"
+    }
+  },
+  "terminal.integrated.defaultProfile.windows": "Git Bash",
+
   // エディタ設定
   "editor.renderWhitespace": "all", // すべての空白文字を表示
   "editor.formatOnSave": false, // 保存時の自動フォーマットを無効化


### PR DESCRIPTION
Windows環境でのターミナル設定を追加し、Git Bashをデフォルトプロファイルとして設定しました。