### PR TITLE
[add] bashrcのシンボリックリンクを追加

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -13,8 +13,6 @@
         // コード整形・補助
         "esbenp.prettier-vscode",
         "mechatroner.rainbow-csv",
-        // APIテスト・開発
-        "postman.postman-for-vscode",
         // エディタ操作・ライブプレビュー
         "vscodevim.vim",
         "ritwickdey.liveserver"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## 管理しているツール
 
-- Bash（Linuxのみ）
+- Bash
 - Vim
 - Git
 - VSCode

--- a/windows/ps1/remove_dotfile_links.ps1
+++ b/windows/ps1/remove_dotfile_links.ps1
@@ -8,7 +8,8 @@ $links = @(
     "$HOME\.gitconfig",  # Gitの設定ファイルへのリンク
     "$HOME\.gitconfig.local",  # Gitの個人設定ファイルへのリンク
     "$HOME\AppData\Roaming\Code\User\settings.json",  # VSCodeの設定ファイルへのリンク
-    "$HOME\AppData\Roaming\Code\User\keybindings.json"  # VSCodeのキーバインド設定ファイルへのリンク
+    "$HOME\AppData\Roaming\Code\User\keybindings.json",  # VSCodeのキーバインド設定ファイルへのリンク
+    "$HOME\.bashrc"  # bashrc（Git Bash用）へのリンク
 )
  
 # $linksに入っている各パスについて、順番に処理します。

--- a/windows/ps1/setup_dotfiles.ps1
+++ b/windows/ps1/setup_dotfiles.ps1
@@ -21,6 +21,7 @@ $git_email = Read-Host "Gitのメールアドレスを入力してください"
 New-Item -ItemType SymbolicLink -Path "$HOME\.vimrc" -Target "$DOTFILES_DIR\.vimrc" -Force | Out-Null  # Vimの設定
 New-Item -ItemType SymbolicLink -Path "$HOME\.gitconfig" -Target "$DOTFILES_DIR\.gitconfig" -Force | Out-Null  # Gitの設定
 New-Item -ItemType SymbolicLink -Path "$HOME\.gitconfig.local" -Target "$DOTFILES_DIR\.gitconfig.local" -Force | Out-Null  # Gitの個人設定
+New-Item -ItemType SymbolicLink -Path "$HOME\.bashrc" -Target "$DOTFILES_DIR\.bashrc" -Force | Out-Null  # bashrcの設定
 
 # VSCodeのユーザー設定ディレクトリのパスを作成
 $codeUserDir = "$HOME\AppData\Roaming\Code\User"


### PR DESCRIPTION
[remove] 不要なVSCode拡張機能を削除

拡張機能のリストからAPIテスト用のPostman拡張を削除しました。
これにより、推奨される拡張機能がより関連性の高いものになります。

[add] bashrcのシンボリックリンクを追加

Windows環境でのbashrc設定を管理するために、シンボリックリンクを追加しました。
これにより、Git Bashの設定が簡単に適用できるようになります。