### PR TITLE
[update] remove_dotfile_links.shのリンクフォーマットを修正

### DIFF
--- a/setup_linux/remove_dotfile_links.sh
+++ b/setup_linux/remove_dotfile_links.sh
@@ -7,8 +7,8 @@ links="\
     $HOME/.gitconfig \
     $HOME/.gitconfig.local \
     $HOME/.config/Code/User/settings.json \
-    $HOME/.config/Code/User/keybindings.json\
-    $HOME/.alacritty.toml\
+    $HOME/.config/Code/User/keybindings.json \
+    $HOME/.alacritty.toml \
 "
 
 # シンボリックリンクを削除


### PR DESCRIPTION
シンボリックリンクのリストにおいて、行末のスペースを追加しました。
これにより、スクリプトの可読性が向上します。