### PR TITLE
[update] VSCodeのプロンプトディレクトリのシンボリックリンクを修正

### DIFF
--- a/setup_linux/setup_dotfiles.sh
+++ b/setup_linux/setup_dotfiles.sh
@@ -22,7 +22,7 @@ ln -sfn "$DOTFILES_DIR/.gitconfig.local" "$HOME/.gitconfig.local"
 mkdir -p "$HOME/.config/Code/User"
 ln -sfn "$DOTFILES_DIR/vscode/settings.json" "$HOME/.config/Code/User/settings.json"
 ln -sfn "$DOTFILES_DIR/vscode/keybindings.json" "$HOME/.config/Code/User/keybindings.json"
-ln -sfn "$DOTFILES_DIR/vscode/prompts" "$HOME/.config/Code/User/prompts"
+ln -sfn "$DOTFILES_DIR/vscode/prompts" "$HOME/.config/Code/User/"
 ln -sfn "$DOTFILES_DIR/alacritty.toml" "$HOME/.alacritty.toml"
 
 # 完了メッセージを表示


### PR DESCRIPTION
シンボリックリンクの作成先を明確にするため、VSCodeのプロンプトディレクトリのリンクを修正しました。