### PR TITLE
[remove] 不要なMarkdown Lint拡張機能を削除

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,7 +8,6 @@
         "github.copilot",
         // 日本語・Markdown関連
         "ms-ceintl.vscode-language-pack-ja",
-        "DavidAnson.vscode-markdownlint",
         "takumii.markdowntable",
         // コード整形・補助
         "esbenp.prettier-vscode",

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -20,7 +20,6 @@
   // ミニマップを無効化
   "editor.minimap.enabled": false,
   "[markdown]": {
-    "editor.defaultFormatter": "DavidAnson.vscode-markdownlint",
     "editor.wordWrap": "off" // マークダウンの折り返しを無効化
   },
 
@@ -44,13 +43,6 @@
   // Copilot Chatの暗黙的コンテキストを無効化
   "chat.implicitContext.enabled": {
     "panel": "never"
-  },
-
-  // markdownlintのルール設定
-  "markdownlint.config": {
-    "ul-style": {
-      "style": "asterisk"
-    }
   },
 
   // GitHub Copilot設定


### PR DESCRIPTION
拡張機能リストからDavidAnson.vscode-markdownlintを削除しました。
設定ファイルからも関連する設定を削除し、整理を行いました。