### PR TITLE
[fix]vimrcのlazygitの設定を変更

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -113,4 +113,4 @@ nnoremap <leader>e :Fern . -reveal=%<CR>
 " <leader>fでfzf.vimを起動
 nnoremap <leader>f :Files<CR>
 " <leader>gでlazygitを起動
-nnoremap <leader>g :silent !lazygit<CR>:redraw!<CR>
+nnoremap <leader>g :tab terminal ++close lazygit<CR>


### PR DESCRIPTION
lazygitを新しいタブで開くようにしました。
windows terminalで描画がおかしくなるためです。