### PR TITLE
[update]gitとdeltaの連携を解除

### DIFF
--- a/dot_config/git/config
+++ b/dot_config/git/config
@@ -3,7 +3,6 @@
         ignorecase = false     # 大文字小文字を区別する
         quotepath = false      # パスをクォートせずUTF-8表示
         editor = vi            # デフォルトエディタをviにする
-        pager = delta          # ページャーにdeltaを使用
 [pull]
         rebase = false         # pull時にrebaseしない
 [fetch]
@@ -12,8 +11,3 @@
         ui = auto              # 色表示を自動判定
 [include]
         path = config.local    # ローカル設定を読み込む
-[interactive]
-        diffFilter = delta --color-only # 対話的diffでdeltaを使用
-[delta]
-        navigate = true        # n/Nで差分移動を有効化
-        dark = true            # ダークテーマを使用


### PR DESCRIPTION
lazygitとdeltaの連携は解除していません。
deltaがない環境でgitを使うときに困らないようにするため、保険。
基本はlazygitから差分を見るので困らない。
