### PR TITLE
[update]mini.pickでバッファをあいまい検索できるように変更

### DIFF
--- a/dot_config/Code/User/keybindings.json
+++ b/dot_config/Code/User/keybindings.json
@@ -37,6 +37,12 @@
     "when": "editorTextFocus && neovim.mode != insert"
   },
   {
+    // Neovimのインサートモード以外で<space>bを押すと開いているエディタの一覧を表示
+    "key": "space b",
+    "command": "workbench.action.showAllEditors",
+    "when": "editorTextFocus && neovim.mode != insert"
+  },
+  {
     // Neovimのインサートモード以外で<space>fを押すとあいまい検索を開く
     "key": "space f",
     "command": "workbench.action.terminal.searchWorkspace",

--- a/dot_config/nvim/lua/keymaps.lua
+++ b/dot_config/nvim/lua/keymaps.lua
@@ -20,6 +20,9 @@ if not vim.g.vscode then
   -- <leader>pでmini.pickのファイル検索を起動
   vim.keymap.set('n', '<leader>p', ':Pick files<CR>', { desc = 'Pick files' })
 
+  -- <leader>bでmini.pickのバッファ検索を起動
+  vim.keymap.set('n', '<leader>b', ':Pick buffers<CR>')
+
   -- <leader>fでmini.pickの横断したあいまい検索を起動
   vim.keymap.set('n', '<leader>f', function()
     require('mini.pick').builtin.grep_live()


### PR DESCRIPTION
過去に消した設定を復活させた。
`:b`に補完が効くと知り削除していたが、mini.pickのほうが使いやすいため復活
