### PR TITLE
[update]Fterm.nvimを導入

### DIFF
--- a/dot_config/nvim/lua/keymaps.lua
+++ b/dot_config/nvim/lua/keymaps.lua
@@ -21,7 +21,7 @@ if not vim.g.vscode then
   vim.keymap.set('n', '<leader>p', ':Pick files<CR>', { desc = 'Pick files' })
 
   -- <leader>bでmini.pickのバッファ検索を起動
-  vim.keymap.set('n', '<leader>b', ':Pick buffers<CR>')
+  vim.keymap.set('n', '<leader>b', ':Pick buffers<CR>', { desc = 'Pick buffers' })
 
   -- <leader>fでmini.pickの横断したあいまい検索を起動
   vim.keymap.set('n', '<leader>f', function()
@@ -53,7 +53,20 @@ if not vim.g.vscode then
   end, { desc = 'Show notifications' })
 
   -- lazygitを開く
-  vim.keymap.set('n', '<leader>g', ':LazyGit<CR>', { desc = 'LazyGit' })
+  vim.keymap.set('n', '<leader>g', function()
+    require('FTerm').run('lazygit && exit')
+  end, { desc = 'LazyGit' })
+
+  -- マークダウンをプレビューする（markdown ファイルのみ）
+  vim.api.nvim_create_autocmd('FileType', {
+    pattern = 'markdown',
+    callback = function()
+      vim.keymap.set('n', '<leader>r', function()
+        local buf = vim.api.nvim_buf_get_name(0)
+        require('FTerm').run('glow -t ' .. buf .. ' && exit')
+      end, { desc = 'Preview markdown', buffer = true })
+    end,
+  })
 end
 
 -- mini.align用のキーマップ設定を返す関数

--- a/dot_config/nvim/lua/plugins.lua
+++ b/dot_config/nvim/lua/plugins.lua
@@ -62,14 +62,22 @@ if not vim.g.vscode then
 
     -- lazygit
     add({
-      source = 'kdheepak/lazygit.nvim',
+      source = 'numToStr/FTerm.nvim',
+    })
+    require('FTerm').setup({
+      dimensions = {
+          height = 0.9,
+          width = 0.9,
+      },
     })
 
     -- floatmemo
     add({
       source = 'sh1Nome/floatmemo.nvim',
     })
-    require('floatmemo').setup()
+    require('floatmemo').setup({
+      border = 'single'
+    })
 
     -- lsp
     add({


### PR DESCRIPTION
* lazygit.nvimを削除し、Fterm.nvimから起動するように変更
* glowを起動するキーマップを追加
* floatmemo.nvimのデザインをsingleに変更
* キーマップに説明を追加
