### PR TITLE
[update]FTerm.nvimのWindows設定

### DIFF
--- a/dot_config/nvim/lua/keymaps.lua
+++ b/dot_config/nvim/lua/keymaps.lua
@@ -62,7 +62,8 @@ if not vim.g.vscode then
     pattern = 'markdown',
     callback = function()
       vim.keymap.set('n', '<leader>r', function()
-        local buf = vim.api.nvim_buf_get_name(0)
+        -- 開いているバッファのパスの区切り文字を置換（Windows用）
+        local buf = vim.api.nvim_buf_get_name(0):gsub("\\", "/")
         require('FTerm').run('glow -t ' .. buf .. ' && exit')
       end, { desc = 'Preview markdown', buffer = true })
     end,

--- a/dot_config/nvim/lua/plugins.lua
+++ b/dot_config/nvim/lua/plugins.lua
@@ -65,6 +65,7 @@ if not vim.g.vscode then
       source = 'numToStr/FTerm.nvim',
     })
     require('FTerm').setup({
+      cmd = 'bash', -- Windowsでは指定しないと動かない
       dimensions = {
           height = 0.9,
           width = 0.9,


### PR DESCRIPTION
* パスの区切り文字を置換
* cmdを指定（Windowsでは$SHELLが使えないため）
