### PR TITLE
[update]mini.jump2dを再び導入

### DIFF
--- a/dot_config/nvim/lua/plugins.lua
+++ b/dot_config/nvim/lua/plugins.lua
@@ -153,7 +153,23 @@ now(function()
 end)
 
 later(function()
-	require("mini.jump").setup() -- ジャンプ機能（f）
+	-- ジャンプ機能（<CR>）
+	local jump2d = require("mini.jump2d")
+	jump2d.setup({
+		-- 空白以外の2文字に1つジャンプスポットを生成
+		spotter = jump2d.gen_spotter.pattern("%S%S"),
+		-- ジャンプスポットのラベルを定義
+		labels = "abcdefghijklmnopqrstuvwxyz1234567890",
+		view = {
+			-- 3ステップ先まで表示
+			n_steps_ahead = 3,
+		},
+		-- 現在のウィンドウでのみ表示
+		allowed_windows = {
+			current = true,
+			not_current = false,
+		},
+	})
 	-- サラウンド機能（sa, sr, sd）
 	require("mini.surround").setup({
 		custom_surroundings = {


### PR DESCRIPTION
mini.jumpで日本語の移動が大変だったので、jump2dを再び導入。
2文字単位でスポットするようにしている。
少ないタイプ数で移動できるようにラベルを増やしてある。
