### PR TITLE
[update]シェルのプロンプトを改行する

### DIFF
--- a/dot_config/bash/bashrc
+++ b/dot_config/bash/bashrc
@@ -17,21 +17,9 @@ HISTFILESIZE=2000
 # 各コマンド実行後にウィンドウサイズを確認し、必要なら LINES と COLUMNS を更新
 shopt -s checkwinsize
 
-# ターミナルの種類が xterm-color または 256色対応の場合、色付きプロンプトを有効化
-case "$TERM" in
-    xterm-color|*-256color)
-        if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
-            color_prompt=yes
-        fi
-        ;;
-esac
-
-if [ "$color_prompt" = yes ]; then
-    PS1='\[\033]0;\W\a\]\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[33m\]$(parse_git_branch)\[\033[00m\]\$ '
-else
-    PS1='\[\033]0;\W\a\]\u@\h:\w$(parse_git_branch)\$ '
-fi
-unset color_prompt force_color_prompt
+# プロンプト設定
+PS1='\[\033]0;\W\a\]\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[33m\]$(parse_git_branch)\[\033[00m\]
+\$ '
 
 # Gitブランチ名を取得する関数
 parse_git_branch() {

--- a/dot_config/powershell/Microsoft.PowerShell_profile.ps1
+++ b/dot_config/powershell/Microsoft.PowerShell_profile.ps1
@@ -28,7 +28,7 @@ function prompt {
     $host.UI.RawUI.WindowTitle = Split-Path -Leaf (Get-Location).Path
     # ANSIエスケープコードを使用してプロンプトの色を設定
     $esc = [char]27
-    return "${esc}[01;32m$env:USERNAME@$env:COMPUTERNAME${esc}[0m:${esc}[01;34m$((Get-Location).Path)${esc}[0m${esc}[33m$(Get-GitBranchName)${esc}[0m> "
+    return "${esc}[01;32m$env:USERNAME@$env:COMPUTERNAME${esc}[0m:${esc}[01;34m$((Get-Location).Path)${esc}[0m${esc}[33m$(Get-GitBranchName)${esc}[0m`n> "
 }
 
 # miseのエイリアス


### PR DESCRIPTION
長いブランチ名やパスを扱うことがあり、コマンド入力直前で改行されていたほうが見やすいため。  
また、bashrcで色表示に対応したターミナルかどうかを判定するのをやめた。  
デスクトップ環境で色表示に対応していないターミナルを使うことがないため。  
close #218 
