### PR TITLE
[update]floatcliの設定を修正

### DIFF
--- a/dot_config/nvim/lua/keymaps.lua
+++ b/dot_config/nvim/lua/keymaps.lua
@@ -64,19 +64,10 @@ if not vim.g.vscode then
 	end, { desc = "Show notifications" })
 
 	-- floatcliの設定
-	-- Windows対応: コマンド引数をダブルクオートで囲む
-	local function quote_for_windows(commands)
-		if vim.fn.has("win32") == 1 then
-			return vim.tbl_map(function(cmd)
-				return '"' .. cmd .. '"'
-			end, commands)
-		end
-		return commands
-	end
 	-- bashを開く
 	vim.keymap.set("n", "<leader>s", function()
 		require("floatcli").open({
-			commands = quote_for_windows({ "bash" }),
+			commands = { "bash" },
 		})
 	end, { desc = "Float shell" })
 	-- マークダウンをプレビューする（markdown ファイルのみ）
@@ -87,7 +78,7 @@ if not vim.g.vscode then
 				-- 開いているバッファのパスの区切り文字を置換（Windows用）
 				local buf = vim.api.nvim_buf_get_name(0):gsub("\\", "/")
 				require("floatcli").open({
-					commands = quote_for_windows({ "glow -t " .. buf }),
+					commands = { "glow -t " .. buf },
 				})
 			end, { desc = "Preview markdown", buffer = true })
 		end,

--- a/dot_config/nvim/lua/settings.lua
+++ b/dot_config/nvim/lua/settings.lua
@@ -11,6 +11,7 @@ vim.opt.clipboard = { "unnamed", "unnamedplus" } -- システムクリップボ�
 if vim.fn.has("win32") == 1 then
 	vim.opt.shell = "C:\\Progra~1\\Git\\bin\\bash.exe"
 	vim.opt.shellcmdflag = "-c"
+	vim.opt.shellxquote = ""
 end
 
 -- 表示系


### PR DESCRIPTION
Windowsでfloatcliがうまく動かない問題に暫定対応していたが、根本原因がわかった。
vimのターミナルとしてgit bashを使うときはshellxquoteを空文字にする必要があった。
