### PR TITLE
[update]bashにcwエイリアスを追加

### DIFF
--- a/dot_config/bash/bashrc
+++ b/dot_config/bash/bashrc
@@ -121,8 +121,9 @@ fi
 export EDITOR=nvim
 export LANG=ja_JP.UTF-8
 
-# miseのエイリアス
+# エイリアス
 alias x="mise x --"
+alias cw="copilot --allow-tool 'write' --model claude-haiku-4.5"
 
 # ローカル設定ファイルの読み込み
 if [ -f ~/.bashrc.local ]; then

--- a/dot_config/mise/mise.toml
+++ b/dot_config/mise/mise.toml
@@ -4,28 +4,5 @@ run = '''
 mise ls | awk '{print $1}' | xargs -n1 mise tool | grep '^Backend:'
 '''
 
-[tasks.copilot-write]
-description = "Launch GitHub Copilot CLI with write tool enabled"
-run = '''
-cat << 'EOF'
-Select mode:
-  n) new
-  c) continue
-  r) resume
-EOF
-read -p "Enter (n/c/r): " mode
-
-if [ "$mode" = "n" ]; then
-  copilot --allow-tool 'write' --model claude-haiku-4.5
-elif [ "$mode" = "c" ]; then
-  copilot --allow-tool 'write' --model claude-haiku-4.5 --continue
-elif [ "$mode" = "r" ]; then
-  copilot --allow-tool 'write' --model claude-haiku-4.5 --resume
-else
-  echo "Invalid input: $mode"
-  exit 1
-fi
-'''
-
 [settings]
 windows_default_inline_shell_args = "C:/Progra~1/Git/bin/bash.exe --noprofile -c"


### PR DESCRIPTION
miseからcopilot-writeタスクを削除。
copilotの対話モードで`/resume`が使えるので、問題なし。
copilot-writeは長いので、cwに省略。
