### PR TITLE
[fix]weztermのタブバーを修正

### DIFF
--- a/dot_config/wezterm/wezterm.lua
+++ b/dot_config/wezterm/wezterm.lua
@@ -15,13 +15,15 @@ config.window_background_opacity = 0.75 -- 背景の透明度（0.0-1.0）
 config.show_new_tab_button_in_tab_bar = false -- タブバーの「+」ボタンを非表示
 config.tab_bar_at_bottom = true -- タブバーをウィンドウの下に表示
 config.use_fancy_tab_bar = false -- レトロなタブバーを使用する
+config.tab_max_width = 32 -- タブの最大幅
+
 local inactive_tab = {
 	bg_color = "#5c6d74", -- 非アクティブなタブの背景色
 	fg_color = "#ffffff", -- 非アクティブなタブの文字色
 }
 config.colors = {
 	tab_bar = {
-		background = "none",
+		background = "none", -- タブバーの背景透過
 
 		-- アクティブタブ
 		active_tab = {
@@ -36,6 +38,18 @@ config.colors = {
 		inactive_tab_hover = inactive_tab,
 	},
 }
+
+-- タブバーの表示カスタマイズ
+wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_width)
+	local title = tab.active_pane.title
+	-- パディング分を確保してテキストを切り詰め
+	if wezterm.column_width(title) > max_width - 4 then
+		title = wezterm.truncate_right(title, max_width - (4 + wezterm.column_width("…"))) .. "…"
+	end
+	return {
+		{ Text = "  " .. title .. "  " },
+	}
+end)
 
 -- フォント
 config.font_size = 11 -- フォントサイズ


### PR DESCRIPTION
* タブ名の左右に空白を追加
  * タブ名がカットされるときは…と表示する
* タブの最大幅を指定
