### PR TITLE
[update]miseでpythonをコンパイルしない

### DIFF
--- a/dot_config/mise/mise.toml
+++ b/dot_config/mise/mise.toml
@@ -6,3 +6,6 @@ mise ls | awk '{print $1}' | xargs -n1 mise tool | grep '^Backend:'
 
 [settings]
 windows_default_inline_shell_args = "C:/Progra~1/Git/bin/bash.exe --noprofile -c"
+
+[settings.python]
+compile = false


### PR DESCRIPTION
最新のPythonが必要になることが、ないため
