### PR TITLE
[update]miseでnpmへの依存を削除

### DIFF
--- a/dot_config/mise/mise.default.toml
+++ b/dot_config/mise/mise.default.toml
@@ -10,5 +10,5 @@
 "aqua:ttyd" = "latest"
 "aqua:usage" = "latest"
 "aqua:vhs" = "latest"
-"npm:@github/copilot" = "latest"
+"github:github/copilot-cli" = "latest"
 "gitlab:gitlab-org/cli" = "latest"

--- a/dot_config/mise/mise.minimal.toml
+++ b/dot_config/mise/mise.minimal.toml
@@ -1,8 +1,7 @@
 [tools]
-"core:node" = "latest"
 "aqua:delta" = "latest"
 "aqua:gh" = "latest"
 "aqua:neovim" = "latest"
 "aqua:ripgrep" = "latest"
-"npm:@github/copilot" = "latest"
+"github:github/copilot-cli" = "latest"
 "gitlab:gitlab-org/cli" = "latest"


### PR DESCRIPTION
npm経由でcopilot cliをダウンロードしていたが、
github releaseからインストールするようにした。
github releaseからインストールする手順は
github公式のドキュメントにも記載あり。
https://docs.github.com/en/copilot/how-tos/copilot-cli/install-copilot-cli
