### PR TITLE
Copilot通知フックの設定を追加

### DIFF
--- a/dot_copilot/hooks/notification.json
+++ b/dot_copilot/hooks/notification.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "notification": [
+      {
+        "type": "command",
+        "bash": "notify-send 'Copilot' 'Reply completed' && paplay /usr/share/sounds/freedesktop/stereo/complete.oga 2>/dev/null || true"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
- notification.json を追加
  * notification hook イベント（v1.0.18）で導入
  * グローバルフック ~/.copilot/hooks のサポート（v0.0.422）
- デスクトップ通知と音声アラートを設定
- Copilot応答完了時にトリガー
