### PR TITLE
[update] OpenCodeの許可コマンドを更新

### DIFF
--- a/dot_config/opencode/opencode.json
+++ b/dot_config/opencode/opencode.json
@@ -36,10 +36,14 @@
       "git log *": "allow",
       "git diff *": "allow",
       "git show *": "allow",
-      "rg *": "allow",
-      "grep *": "allow",
-      "head *": "allow",
-      "tail *": "allow"
+      "gh issue list *": "allow",
+      "gh issue view *": "allow",
+      "gh pr list *": "allow",
+      "gh pr view *": "allow",
+      "glab issue list *": "allow",
+      "glab issue view *": "allow",
+      "glab mr list *": "allow",
+      "glab mr view *": "allow"
     },
     "skill": "allow",
     "todoread": "allow",


### PR DESCRIPTION
セキュリティリスクを考慮し、grep、rg、head、tail などの
汎用的すぎるコマンドを削除。

GitHub/GitLab のCLIツール関連コマンド（gh/glab の issue/mr 操作）を
追加。これらは副作用がないため安全に許可できる。
