### PR TITLE
Allow gh pr diff and glab mr diff commands in OpenCode permissions

### DIFF
--- a/dot_config/opencode/opencode.json
+++ b/dot_config/opencode/opencode.json
@@ -40,10 +40,12 @@
       "gh issue view *": "allow",
       "gh pr list *": "allow",
       "gh pr view *": "allow",
+      "gh pr diff *": "allow",
       "glab issue list *": "allow",
       "glab issue view *": "allow",
       "glab mr list *": "allow",
-      "glab mr view *": "allow"
+      "glab mr view *": "allow",
+      "glab mr diff *": "allow"
     },
     "skill": "allow",
     "todoread": "allow",


### PR DESCRIPTION
## Summary

- Add `gh pr diff *` to the allowed bash commands in OpenCode
- Add `glab mr diff *` to the allowed bash commands in OpenCode

## Details

Both commands are read-only operations that display changes in pull/merge requests without modifying any data or triggering side effects.