### PR TITLE
notification プラグインを改善：最新メッセージの動的通知機能を追加

### DIFF
--- a/dot_config/opencode/plugins/notification.js
+++ b/dot_config/opencode/plugins/notification.js
@@ -22,9 +22,45 @@ export const NotificationPlugin = async ({
    * @returns {Promise<void>}
    */
   const sendNotification = async (title, message) => {
-    await $`printf "\e]777;notify;%s;%s\e\\" ${title} ${message}`;
+    await $`printf "\e]777;notify;%s;%s\e\\" "${title}" "${message}"`;
     if (process.platform === "linux") {
       await $`paplay /usr/share/sounds/freedesktop/stereo/complete.oga`;
+    }
+  };
+
+  /**
+   * セッションの最新メッセージを取得し、最初の行を返す
+   * メッセージが200文字を超える場合は省略され、見つからない場合または エラー時はデフォルトメッセージを返す
+   * @param {string} sessionID - セッションID
+   * @returns {Promise<string>} メッセージの最初の行（最大200文字）、見つからない場合は "No message"、取得失敗時は "Failed to get message"
+   */
+  const getLatestMessage = async (sessionID) => {
+    try {
+      const messages = await client.session.messages({
+        path: { id: sessionID },
+      });
+
+      if (messages.data?.length > 0) {
+        // 最後のメッセージを取得
+        const lastMessage = messages.data[messages.data.length - 1];
+
+        if (lastMessage.info?.role === "assistant") {
+          const textPart = lastMessage.parts?.find((p) => p.type === "text");
+          const text = textPart?.text;
+          if (text) {
+            const result =
+              text.length > 200 ? text.substring(0, 200) + "..." : text;
+
+            const firstLine = result.split("\n")[0];
+
+            return firstLine;
+          }
+        }
+      }
+
+      return "No message";
+    } catch (error) {
+      return "Failed to get message";
     }
   };
 
@@ -37,10 +73,10 @@ export const NotificationPlugin = async ({
      * @returns {Promise<void>}
      */
     event: async ({ event }) => {
-      if (event.type === "permission.asked") {
-        await sendNotification("OpenCode", "Approval needed");
-      } else if (event.type === "session.idle") {
-        await sendNotification("OpenCode", "Reply completed");
+      if (event.type === "permission.asked" || event.type === "session.idle") {
+        const message = await getLatestMessage(event.properties.sessionID);
+
+        await sendNotification("OpenCode", message);
       }
     },
   };

--- a/dot_config/opencode/plugins/notification.js
+++ b/dot_config/opencode/plugins/notification.js
@@ -1,5 +1,13 @@
-// OpenCode通知プラグイン
-// ユーザーの操作が必要な時に、プラットフォーム固有の通知を送信
+/**
+ * ユーザーの操作が必要な時にプラットフォーム固有の通知を送信するプラグイン
+ * @param {Object} params
+ * @param {Object} params.project - プロジェクト情報
+ * @param {Object} params.client - OpenCode SDK クライアント
+ * @param {Function} params.$ - Bun shell API
+ * @param {string} params.directory - 現在の作業ディレクトリ
+ * @param {string} params.worktree - Git ワークツリーパス
+ * @returns {Promise<Object>} プラグインハンドラーオブジェクト
+ */
 export const NotificationPlugin = async ({
   project,
   client,
@@ -7,29 +15,32 @@ export const NotificationPlugin = async ({
   directory,
   worktree,
 }) => {
-  // プラットフォーム固有の通知を送信
+  /**
+   * プラットフォーム固有の通知を送信
+   * @param {string} title - 通知のタイトル
+   * @param {string} message - 通知のメッセージ
+   * @returns {Promise<void>}
+   */
   const sendNotification = async (title, message) => {
     await $`printf "\e]777;notify;%s;%s\e\\" ${title} ${message}`;
     if (process.platform === "linux") {
-      // Linux: notify-send で通知してから paplay で音を鳴らす
       await $`paplay /usr/share/sounds/freedesktop/stereo/complete.oga`;
     }
   };
 
-  // プラグインのハンドラーオブジェクトを返す
   return {
-    // イベントハンドラー: エージェントが許可を求めたとき、返信が終わったとき
+    /**
+     * イベント発生時のハンドラー
+     * @param {Object} params
+     * @param {Object} params.event - イベントオブジェクト
+     * @param {string} params.event.type - イベントの種類
+     * @returns {Promise<void>}
+     */
     event: async ({ event }) => {
       if (event.type === "permission.asked") {
         await sendNotification("OpenCode", "Approval needed");
       } else if (event.type === "session.idle") {
         await sendNotification("OpenCode", "Reply completed");
-      }
-    },
-    // ツール実行前のハンドラー: questionツールを実行したとき
-    "tool.execute.before": async (input, output) => {
-      if (input.tool === "question") {
-        await sendNotification("OpenCode", "Please answer");
       }
     },
   };


### PR DESCRIPTION
## 概要

notification プラグインを改善し、セッションの最新メッセージを動的に通知する機能を追加しました。

## 変更内容

- `sendNotification` 関数の引数をクォート化して安全性向上
- `getLatestMessage` 関数を実装：セッションの最新メッセージを取得し、最初の行を返す（最大200文字まで表示）
- `permission.asked` と `session.idle` イベント処理を統合し、動的にメッセージを通知

## 技術的な詳細

- メッセージが200文字を超える場合は省略表示
- エラーハンドリングで失敗時のデフォルトメッセージを返す
- セッション最新メッセージ取得失敗時は "Failed to get message" を返す