### PR TITLE
fix: msys2 bash の互換性のため shellcmdflag を設定

### DIFF
--- a/.chezmoitemplates/nvim/lua/settings.lua
+++ b/.chezmoitemplates/nvim/lua/settings.lua
@@ -7,6 +7,7 @@ vim.opt.swapfile = false -- スワップファイルを作成禁止
 vim.opt.backspace = { "indent", "eol", "start" } -- バックスペース有効化
 vim.opt.clipboard = { "unnamed", "unnamedplus" } -- システムクリップボードを利用
 vim.opt.updatetime = 1000 -- カーソル停止と判定されるまでの時間(ms)
+vim.opt.shellcmdflag = "-c" -- シェルに渡されるフラグ（デフォルトが -c だが、 msys2 では指定が必要）
 
 -- 表示系
 vim.opt.showcmd = true -- コマンドを表示


### PR DESCRIPTION
## 概要
Windows デフォルトのシェルコマンドフラグ `/s /c` は msys2 の bash では互換性がないため、`-c` フラグを明示的に設定します。

## 変更内容
- nvim の settings.lua に `vim.opt.shellcmdflag = "-c"` を追加

## 理由
msys2 の bash でシェルコマンドが正常に動作するようにするため