### PR TITLE
mini.pick のウィンドウ幅をビューポート変更に対応させる

### DIFF
--- a/.chezmoitemplates/nvim/lua/plugins.lua
+++ b/.chezmoitemplates/nvim/lua/plugins.lua
@@ -91,9 +91,11 @@ if not vim.g.vscode then
 		}) -- ファイラー
 		require("mini.pick").setup({
 			window = {
-				config = {
-					width = math.floor((vim.o.columns - 8) / 2),
-				},
+				config = function()
+					return {
+						width = math.floor((vim.o.columns - 8) / 2),
+					}
+				end,
 			},
 		}) -- ピッカー
 		local animate = require("mini.animate") -- アニメーション


### PR DESCRIPTION
## 概要

mini.pick のウィンドウ幅をビューポート変更に対応させました。

## 変更内容

- `window.config` を静的なテーブルから関数に変更
- ピッカー起動時に毎回 `vim.o.columns` を評価して幅を計算

## 動作

ウィンドウをリサイズしてからピッカーを開き直すと、最新の画面幅に対応したウィンドウ幅でピッカーが表示されます。