### PR TITLE
Enable OpenAI provider in opencode config

### DIFF
--- a/dot_config/opencode/opencode.json
+++ b/dot_config/opencode/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "enabled_providers": ["github-copilot"],
+  "enabled_providers": ["github-copilot", "openai"],
   "model": "github-copilot/claude-haiku-4.5",
   "small_model": "github-copilot/gpt-5-mini",
   "agent": {


### PR DESCRIPTION
Enable the OpenAI provider alongside the existing GitHub Copilot provider in the opencode configuration.