### PR TITLE
feat: mise で管理しているため autoupdate を無効化

### DIFF
--- a/dot_config/opencode/opencode.json
+++ b/dot_config/opencode/opencode.json
@@ -58,5 +58,6 @@
   "share": "disabled",
   "tui": {
     "diff_style": "stacked"
-  }
+  },
+  "autoupdate": false
 }


### PR DESCRIPTION
OpenCode の自動更新を無効化します。mise で管理しているため、自動更新の必要はありません。