### PR TITLE
Update mini.pick and mini.clue keymaps and settings

### DIFF
--- a/.chezmoitemplates/nvim/lua/keymaps.lua
+++ b/.chezmoitemplates/nvim/lua/keymaps.lua
@@ -40,28 +40,28 @@ else
 	vim.keymap.set("n", "<leader>p", function()
 		local tool = is_git_repo() and "git" or "rg"
 		require("mini.pick").builtin.files({ tool = tool })
-	end, { desc = "Pick files" })
+	end, { desc = "Pick files (S-Tab: show keymaps)" })
 
 	-- mini.pickの横断したあいまい検索を起動（gitリポジトリならgit、そうでないならrg）
 	vim.keymap.set("n", "<leader>f", function()
 		local tool = is_git_repo() and "git" or "rg"
 		require("mini.pick").builtin.grep_live({ tool = tool })
-	end, { desc = "Live grep (C-o: glob)" })
+	end, { desc = "Live grep (C-o: glob, S-Tab: show keymaps)" })
 
 	-- 最近訪問したファイルを起動
 	vim.keymap.set("n", "<leader>v", function()
 		require("mini.extra").pickers.visit_paths()
-	end, { desc = "Pick visited files" })
+	end, { desc = "Pick visited files (S-Tab: show keymaps)" })
 
 	-- mini.pickのヘルプ検索を起動
 	vim.keymap.set("n", "<leader>h", function()
 		require("mini.pick").builtin.help()
-	end, { desc = "Help" })
+	end, { desc = "Help (S-Tab: show keymaps)" })
 
 	-- mini.pickの最後のpickerを再開
 	vim.keymap.set("n", "<leader>r", function()
 		require("mini.pick").builtin.resume()
-	end, { desc = "Resume picker" })
+	end, { desc = "Resume picker (S-Tab: show keymaps)" })
 
 	-- mini.filesを起動
 	vim.keymap.set("n", "<leader>e", function()

--- a/.chezmoitemplates/nvim/lua/plugins.lua
+++ b/.chezmoitemplates/nvim/lua/plugins.lua
@@ -90,6 +90,9 @@ if not vim.g.vscode then
 			mappings = require("keymaps").get_mini_files_mappings(),
 		}) -- ファイラー
 		require("mini.pick").setup({
+			mappings = {
+				choose_marked = "<C-q>",
+			},
 			window = {
 				config = function()
 					return {
@@ -147,6 +150,9 @@ if not vim.g.vscode then
 			},
 			window = {
 				delay = 0, -- 遅延なしで表示
+				config = {
+					width = "auto", -- サイズを自動調整
+				},
 			},
 		}) -- キーマップを表示
 


### PR DESCRIPTION
## Summary
- Add S-Tab hint to mini.pick related keymaps to show available keymaps in mini.clue
- Change choose_marked key from M-CR to C-q (may conflict with terminal)
- Auto-adjust mini.clue window width to prevent long descriptions from being truncated

## Changes
- `keymaps.lua`: Updated descriptions for `<leader>p`, `<leader>f`, `<leader>v`, `<leader>h`, `<leader>r`
- `plugins.lua`: Added `choose_marked = "<C-q>"` to mini.pick setup and `width = "auto"` to mini.clue window config