### PR TITLE
Git設定でpull時のrebaseを有効化

### DIFF
--- a/dot_config/git/config.tmpl
+++ b/dot_config/git/config.tmpl
@@ -1,17 +1,17 @@
 [core]
-    autocrlf = false       # 改行コードを自動変換しない
-    ignorecase = false     # 大文字小文字を区別する
-    quotepath = false      # パスをクォートせずUTF-8表示
+    autocrlf = false # 改行コードを自動変換しない
+    ignorecase = false # 大文字小文字を区別する
+    quotepath = false # パスをクォートせずUTF-8表示
 [pull]
-    rebase = false         # pull時にrebaseしない
+    rebase = true # pull時にrebaseする
 [fetch]
-    prune = true           # 取得時に不要ブランチを自動削除
+    prune = true # 取得時に不要ブランチを自動削除
 [color]
-    ui = auto              # 色表示を自動判定
+    ui = auto # 色表示を自動判定
 [user]
-    name = {{ .gitUserName }}
-    email = {{ .gitEmail }}
+    name = {{ .gitUserName }} # Gitのユーザー名
+    email = {{ .gitEmail }} # Gitのメールアドレス
 {{ if .gitEnableCredential }}
 [credential]
-    provider = generic
+    provider = generic # GCM の汎用向けホスト認証プロバイダー
 {{ end }}


### PR DESCRIPTION
pull.rebaseをtrueに変更し、pullコマンド実行時に自動的にrebaseするように設定。
あわせてコメントのインデントを統一し、ユーザー情報とcredential.providerにコメントを追加
