### PR TITLE
fix: glab コマンドの許可設定と SKILL.md を修正

### DIFF
--- a/dot_agents/skills/cli-tools-gh-glab/SKILL.md
+++ b/dot_agents/skills/cli-tools-gh-glab/SKILL.md
@@ -29,7 +29,7 @@ description: gh/glab で GitHub/GitLab の Issue・PR/MR・CI 状況を確認・
 
 ### MR コメント確認
 
-* `glab mr note ls` - MR のコメントを確認するときに使用
+* `glab mr note list` - MR のコメントを確認するときに使用
 
 ### CI 情報確認
 

--- a/dot_config/opencode/opencode.json
+++ b/dot_config/opencode/opencode.json
@@ -49,7 +49,10 @@
       "glab issue view *": "allow",
       "glab mr list *": "allow",
       "glab mr view *": "allow",
-      "glab mr diff *": "allow"
+      "glab mr diff *": "allow",
+      "glab mr note list *": "allow",
+      "glab ci get *": "allow",
+      "glab ci trace *": "allow"
     },
     "skill": "allow",
     "todoread": "allow",


### PR DESCRIPTION
- glab mr note list, glab ci get, glab ci trace を opencode.json の bash 許可リストに追加
- glab mr note ls から glab mr note list に修正（SKILL.md）
