### PR TITLE
git認証情報ヘルパーをwincredに設定

### DIFF
--- a/dot_config/git/config.tmpl
+++ b/dot_config/git/config.tmpl
@@ -12,6 +12,7 @@
     name = {{ .gitUserName }} # Gitのユーザー名
     email = {{ .gitEmail }} # Gitのメールアドレス
 {{ if .gitEnableCredential }}
-[credential]
+[credential] # https://git-scm.com/doc/credential-helpers
+    helper = wincred # git-credential-wincred を指定
     provider = generic # GCM の汎用向けホスト認証プロバイダー
 {{ end }}


### PR DESCRIPTION
- credential.helperをwincredで指定してWindows環境での安全な認証情報管理を有効化
- credentialセクションに公式ドキュメントリンクを追加してドキュメント整備

close #403
