### PR TITLE
refactor: consolidate mini.pick keymaps to keymaps.lua

### DIFF
--- a/.chezmoitemplates/nvim/lua/keymaps.lua
+++ b/.chezmoitemplates/nvim/lua/keymaps.lua
@@ -143,7 +143,15 @@ local function get_mini_files_mappings()
 	}
 end
 
+-- mini.pick用のキーマップ設定を返す関数
+local function get_mini_pick_mappings()
+	return {
+		choose_marked = "<C-q>",
+	}
+end
+
 return {
 	get_mini_align_mappings = get_mini_align_mappings,
 	get_mini_files_mappings = get_mini_files_mappings,
+	get_mini_pick_mappings = get_mini_pick_mappings,
 }

--- a/.chezmoitemplates/nvim/lua/plugins.lua
+++ b/.chezmoitemplates/nvim/lua/plugins.lua
@@ -90,9 +90,7 @@ if not vim.g.vscode then
 			mappings = require("keymaps").get_mini_files_mappings(),
 		}) -- ファイラー
 		require("mini.pick").setup({
-			mappings = {
-				choose_marked = "<C-q>",
-			},
+			mappings = require("keymaps").get_mini_pick_mappings(),
 			window = {
 				config = function()
 					return {


### PR DESCRIPTION
Move mini.pick mappings configuration to keymaps.lua via get_mini_pick_mappings()
function for consistency with mini.files and mini.align settings.
