### PR TITLE
feat: add mini.snippets with HTML code block and details snippets

### DIFF
--- a/.chezmoitemplates/nvim/lua/commands.lua
+++ b/.chezmoitemplates/nvim/lua/commands.lua
@@ -39,3 +39,9 @@ vim.api.nvim_create_user_command("PandocToClipboard", pandoc_to_clipboard, {
 	nargs = 1,
 	range = true,
 })
+
+vim.api.nvim_create_user_command("SnippetPick", function()
+	MiniSnippets.expand({ match = false })
+end, {
+	desc = "Pick and expand snippets",
+})

--- a/.chezmoitemplates/nvim/lua/plugins.lua
+++ b/.chezmoitemplates/nvim/lua/plugins.lua
@@ -138,6 +138,20 @@ if not vim.g.vscode then
 				["`"] = false,
 			},
 		}) -- 括弧補完
+		require("mini.snippets").setup({
+			snippets = {
+				{
+					prefix = "",
+					body = '<pre><code class="">\n\n</code></pre>',
+					desc = "Code block with language",
+				},
+				{
+					prefix = "",
+					body = "<details><summary></summary>\n\n</details>",
+					desc = "Details/summary",
+				},
+			},
+		}) -- スニペット
 		require("mini.extra").setup() -- 追加
 
 		require("mini.clue").setup({


### PR DESCRIPTION
- Setup mini.snippets in plugins.lua with two HTML snippets
- Add code block snippet with language placeholder
- Add details/summary folding snippet
- Add SnippetPick command to select and expand snippets
