### PR TITLE
refactor(nvim,mise): replace mason.nvim with mise-managed LSPs

### DIFF
--- a/.chezmoitemplates/nvim/lua/lang.lua
+++ b/.chezmoitemplates/nvim/lua/lang.lua
@@ -31,18 +31,16 @@ require("plugins").later(function()
 	else
 		-- Neovim環境: LSP + conform を使用
 		-- `:h lspconfig-all`ですべての設定を見る
-		-- `:Mason`でグラフィカルなステータスウィンドウを開く
-		-- 使用中の LSP
-		-- lua_ls, gopls, jdtls, ts_ls, pyright, clangd, rust-analyzer
-		require("mason").setup({
-			ui = {
-				border = "single",
-			},
+		vim.lsp.enable({
+			"lua_ls",
+			"gopls",
+			"jdtls",
+			"ts_ls",
+			"pyright",
+			"clangd",
+			"rust_analyzer",
+			"zk",
 		})
-		require("mason-lspconfig").setup()
-
-		-- mason で管理していない ls
-		vim.lsp.enable("zk")
 
 		-- 個別のフォーマッター設定
 		local conform = require("conform")

--- a/.chezmoitemplates/nvim/lua/plugins.lua
+++ b/.chezmoitemplates/nvim/lua/plugins.lua
@@ -174,8 +174,6 @@ if not vim.g.vscode then
 			"https://github.com/sh1Nome/floatmemo.nvim",
 			"https://github.com/sh1Nome/floatcli.nvim",
 			"https://github.com/neovim/nvim-lspconfig",
-			"https://github.com/mason-org/mason.nvim",
-			"https://github.com/mason-org/mason-lspconfig.nvim",
 			"https://github.com/stevearc/conform.nvim",
 			"https://github.com/zk-org/zk-nvim",
 			"https://github.com/itchyny/vim-qfedit",

--- a/dot_config/mise/mise.toml.tmpl
+++ b/dot_config/mise/mise.toml.tmpl
@@ -12,7 +12,19 @@
 "core:java" = "latest"
 "core:node" = "latest"
 "core:python" = "latest"
-"core:rust" = "latest"
+"core:rust" = { version = "latest", components = ["rust-analyzer"] }
+
+"aqua:LuaLS/lua-language-server" = "latest"
+"go:golang.org/x/tools/gopls" = "latest"
+"npm:typescript-language-server" = "latest"
+"npm:pyright" = "latest"
+"github:clangd/clangd" = "latest"
+"http:jdtls" = { version = "0", url = "https://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz" }
+
+"aqua:JohnnyMorganz/StyLua" = "latest"
+"npm:sql-formatter" = "latest"
+"npm:prettier" = "latest"
+
 "aqua:tsl0922/ttyd" = "latest"
 "aqua:jdx/usage" = "latest"
 "aqua:charmbracelet/vhs" = "latest"


### PR DESCRIPTION
- Remove mason.nvim and mason-lspconfig.nvim from plugins
- Replace mason.setup()/mason-lspconfig.setup() with vim.lsp.enable()
- Add LSP servers and formatters to mise.toml.tmpl

Closes #484
