### PR TITLE
feat(chezmoi): remove old unused mise config files

### DIFF
--- a/.chezmoiremove
+++ b/.chezmoiremove
@@ -8,3 +8,5 @@
 .copilot
 .codex
 .config/opencode
+.config/mise/mise.default.toml
+.config/mise/mise.minimal.toml


### PR DESCRIPTION
.config/mise/mise.default.toml and mise.minimal.toml are leftover files
from an old setup and no longer needed.
