### PR TITLE
fix(mise): set RUSTUP_TOOLCHAIN per OS using chezmoi template

### DIFF
--- a/dot_config/exact_mise/mise.toml.tmpl
+++ b/dot_config/exact_mise/mise.toml.tmpl
@@ -41,4 +41,8 @@ version_regex = 'jdt-language-server-(.+)\.tar\.gz'
 compile = false
 
 [env]
-RUSTUP_TOOLCHAIN = ''
+{{ if eq .chezmoi.os "windows" -}}
+RUSTUP_TOOLCHAIN = 'stable-x86_64-pc-windows-gnu'
+{{- else if eq .chezmoi.os "linux" -}}
+RUSTUP_TOOLCHAIN = 'stable-x86_64-unknown-linux-gnu'
+{{- end }}


### PR DESCRIPTION
Replace empty string with OS-conditional template for stable toolchain.
