### PR TITLE
refactor(nvim): configure diagnostic float border and simplify K keymap

### DIFF
--- a/.chezmoitemplates/nvim/lua/keymaps.lua
+++ b/.chezmoitemplates/nvim/lua/keymaps.lua
@@ -22,13 +22,7 @@ else
 		require("mini.extra").pickers.lsp({ scope = "references" })
 	end, { desc = "References" })
 	vim.keymap.set("n", "K", function()
-		-- vim.fn.line(".") は 1 始まり、vim.diagnostic.get() の lnum は 0 始まり
-		local diagnostics = vim.diagnostic.get(0, { lnum = vim.fn.line(".") - 1 })
-		if #diagnostics > 0 then
-			vim.diagnostic.open_float({ border = "single" })
-		else
-			vim.lsp.buf.hover({ border = "single" })
-		end
+		vim.lsp.buf.hover({ border = "single" })
 	end, { desc = "Hover or show diagnostics" })
 
 	-- floatmemoを開く

--- a/.chezmoitemplates/nvim/lua/settings.lua
+++ b/.chezmoitemplates/nvim/lua/settings.lua
@@ -41,6 +41,11 @@ vim.opt.tabstop = 2 -- タブ文字の表示幅
 vim.opt.shiftwidth = 2 -- インデント幅
 vim.opt.pumheight = 10 -- ポップアップメニューの最大行数
 vim.opt.pumborder = "single" -- ポップアップメニューのボーダー
+vim.diagnostic.config({
+	float = {
+		border = "single", -- 診断ウィンドウのボーダー
+	},
+})
 vim.opt.list = true -- 不可視文字を表示
 vim.opt.listchars = { space = "·", tab = "▸ ", eol = "¬", nbsp = "_" } -- 不可視文字の表示方法
 vim.opt.laststatus = 2 -- ステータスラインを常に表示


### PR DESCRIPTION
- Add vim.diagnostic.config with float border in settings.lua
- Remove diagnostic check from K keymap; always call lsp.buf.hover
