### PR TITLE
fix(xdg): set default handler for text/html and xhtml+xml to Chrome

### DIFF
--- a/dot_config/mimeapps.list
+++ b/dot_config/mimeapps.list
@@ -1,0 +1,3 @@
+[Default Applications]
+text/html=google-chrome.desktop
+application/xhtml+xml=google-chrome.desktop


### PR DESCRIPTION
xdg-open detects HTML files as application/xhtml+xml via content
sniffing, not just text/html, so both need an explicit default in
mimeapps.list or it falls back to Firefox.

Closes #518
