### PR TITLE
fix(chezmoi): ignore mimeapps.list on non-linux platforms

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -11,6 +11,7 @@ Makefile
 .config/glab-cli
 .config/xfce4
 .config/autostart
+.config/mimeapps.list
 .chezmoiscripts/*.sh
 {{- end }}
 


### PR DESCRIPTION
mimeapps.list is an XDG MIME Applications config with no Windows
equivalent, but it was missed when added in 7beea5f.
