### PR TITLE
chore(bash): remove obsolete code() wrapper for VS Code Neovim

### DIFF
--- a/dot_bashrc
+++ b/dot_bashrc
@@ -161,11 +161,6 @@ if command -v aqua >/dev/null 2>&1; then
   export PATH="$(aqua root-dir)/bin:$PATH"
 fi
 
-# 関数
-# Windows の VS Code Neovim が Neovim を見つけられない問題を回避
-code() {
-    mise exec -- code "$@"
-}
 # chezmoi cd がシェルを起動してしまう問題を回避
 chezmoi-cd() {
     cd $(chezmoi source-path)


### PR DESCRIPTION
Drop the workaround that was no longer needed for VS Code Neovim.
