### PR TITLE
feat(neovim): install via OS package manager instead of mise

### DIFF
--- a/.chezmoitemplates/nvim/lua/settings.lua
+++ b/.chezmoitemplates/nvim/lua/settings.lua
@@ -1,15 +1,6 @@
 -- エディタ設定
 
 -- システム系
--- mise で nvim を起動すると mise の install ディレクトリが PATH に入る。
--- Unix スクリプト（拡張子なし）を Windows で実行できないため mise shims を優先する。
--- ただし mise の shim で win32yank ( yy, dd 等 ) を実行すると、コンソールのウィンドウが開く。
--- nvim_bin を shims より先頭に置き nvim_bin にある本物の win32yank を使わせることで解決。
-if vim.fn.has("win32") == 1 then
-	local nvim_bin = vim.fn.fnamemodify(vim.v.progpath, ":h")
-	local mise_shims = vim.fn.expand("$LOCALAPPDATA") .. "\\mise\\shims"
-	vim.env.PATH = nvim_bin .. ";" .. mise_shims .. ";" .. vim.env.PATH
-end
 vim.opt.fileencoding = "utf-8" -- 文字エンコード
 vim.opt.backup = false -- バックアップファイルを作成禁止
 vim.opt.swapfile = false -- スワップファイルを作成禁止

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build-zk install-zk uninstall-zk mkdir-local-bin install-claude uninstall-claude install-rust uninstall-rust
+.PHONY: help build-zk install-zk uninstall-zk mkdir-local-bin install-neovim uninstall-neovim install-claude uninstall-claude install-rust uninstall-rust
 
 UNAME_S := $(shell uname -s)
 
@@ -11,6 +11,8 @@ endif
 help:
 	@echo "install-zk       Install zk"
 	@echo "uninstall-zk     Uninstall zk"
+	@echo "install-neovim   Install Neovim"
+	@echo "uninstall-neovim Uninstall Neovim"
 	@echo "install-claude   Install Claude Code"
 	@echo "uninstall-claude Uninstall Claude Code"
 	@echo "install-rust     Install Rust via rustup"
@@ -50,6 +52,21 @@ install-zk: mkdir-local-bin
 uninstall-zk:
 	rm -f ~/.local/bin/zk*
 	rm -rf ~/git/my-zk
+
+
+install-neovim:
+ifeq ($(OS),Windows_NT)
+	winget install --id Neovim.Neovim
+else
+	sudo dnf install -y neovim
+endif
+
+uninstall-neovim:
+ifeq ($(OS),Windows_NT)
+	winget uninstall --id Neovim.Neovim
+else
+	sudo dnf remove -y neovim
+endif
 
 
 install-claude:

--- a/dot_config/exact_mise/mise.toml.tmpl
+++ b/dot_config/exact_mise/mise.toml.tmpl
@@ -1,7 +1,6 @@
 [tools]
 "aqua:dandavison/delta" = "latest"
 "aqua:cli/cli" = "latest"
-"aqua:neovim/neovim" = "latest"
 "aqua:BurntSushi/ripgrep" = "latest"
 "aqua:jgm/pandoc" = "latest"
 "aqua:jqlang/jq" = "latest"


### PR DESCRIPTION
Remove neovim from mise and add OS-specific install/uninstall targets
to the Makefile (winget for Windows, dnf for Fedora). Also drop the now
unnecessary mise shims PATH workaround in settings.lua.
