### PR TITLE
docs/adr mise bootstrap

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,4 +1,5 @@
 README.md
+docs
 Makefile
 .local/bin/claude*
 .local/bin/zk*

--- a/docs/adr/0001-do-not-use-mise-tasks-on-windows.md
+++ b/docs/adr/0001-do-not-use-mise-tasks-on-windows.md
@@ -1,0 +1,20 @@
+# Windows では mise タスクを使用しない
+
+## Status
+
+Accepted
+
+## Context
+
+Windows では MSYS2 UCRT64 の bash から mise を利用している。  
+mise タスクは既定で `cmd /c` を使う。bash を直接指定すると、実行環境や引数処理で問題が起きた。  
+原因の詳細は検証していない。
+
+## Decision
+
+Windows では mise タスクを使用せず、Makefile を使用する。
+
+## Consequences
+
+MSYS2 と `cmd` の実行環境が混在する問題を避けられる。  
+一方、mise タスクへ処理を統合できない。

--- a/docs/adr/0002-defer-mise-bootstrap-migration.md
+++ b/docs/adr/0002-defer-mise-bootstrap-migration.md
@@ -1,0 +1,23 @@
+# mise bootstrap への移行を見送る
+
+## Status
+
+Accepted
+
+## Context
+
+chezmoi から `mise bootstrap` への移行を検討したが、次の要件を満たせない。
+
+- mise の Tera テンプレートと chezmoi の `exact_` 相当の削除同期を両立できない
+- Windows のシステムパッケージを `[bootstrap.packages]` で管理できない
+- Windows では mise タスクを使用しない
+
+## Decision
+
+現時点では `mise bootstrap` へ移行しない。
+
+## Consequences
+
+- chezmoi、mise `[tools]`、Makefile の構成を維持する
+- セットアップは複数コマンドのままとなる
+- mise が上記の制約を解消した場合に再評価する

--- a/docs/adr/0003-manage-neovim-and-claude-code-with-makefile.md
+++ b/docs/adr/0003-manage-neovim-and-claude-code-with-makefile.md
@@ -1,0 +1,22 @@
+# Neovim と Claude Code を Makefile で管理する
+
+## Status
+
+Accepted
+
+## Context
+
+Neovim と Claude Code は mise `[tools]` のコマンドを呼び出す。  
+Windows の mise は shims 方式で動作する。  
+Neovim と Claude Code 自体を mise で管理すると、  
+mise のインストールディレクトリが shims より前の `PATH` に入る。  
+その結果、呼び出すコマンドの `.cmd` や `.bat` を解決できない場合がある。
+
+## Decision
+
+Neovim と Claude Code を mise `[tools]` で管理せず、Makefile から OS パッケージまたは公式インストーラーで導入する。
+
+## Consequences
+
+- Neovim と Claude Code から mise の shims を経由してツールを呼び出せる
+- OS ごとの導入処理を Makefile で保守する必要がある


### PR DESCRIPTION
- **docs(adr): avoid mise tasks on Windows**
- **docs(adr): defer mise bootstrap migration**
- **docs(adr): manage Neovim and Claude Code with Makefile**
- **chore(chezmoi): ignore documentation directory**
