### PR TITLE
feat(nvim): add lua_ls settings to resolve vim global and plugin types

### DIFF
--- a/.chezmoitemplates/nvim/lsp/lua_ls.lua
+++ b/.chezmoitemplates/nvim/lsp/lua_ls.lua
@@ -1,0 +1,27 @@
+-- lua_lsの追加設定。`vim.lsp.enable("lua_ls")`で読み込み、nvim-lspconfigの既定設定にマージする
+-- Neovimランタイムの型情報を読ませ、`vim`グローバルの警告解消とhoverを有効化する
+return {
+	settings = {
+		Lua = {
+			runtime = {
+				-- NeovimのLuaはLuaJIT(Lua 5.1相当)のため標準ライブラリの解釈を合わせる
+				version = "LuaJIT",
+				-- `require("keymaps")`のようなNeovim流のモジュール解決を教える(:h lua-module-load)
+				path = { "lua/?.lua", "lua/?/init.lua" },
+			},
+			workspace = {
+				-- サードパーティライブラリ検出時のプロンプトを抑止
+				checkThirdParty = false,
+				-- VIMRUNTIMEに加えプラグインの型も解決する
+				-- rtpではなくvim.pack.get()を見るため、遅延ロード前のプラグインも拾える
+				library = (function()
+					local lib = { vim.env.VIMRUNTIME }
+					for _, plugin in ipairs(vim.pack.get()) do
+						table.insert(lib, plugin.path)
+					end
+					return lib
+				end)(),
+			},
+		},
+	},
+}

--- a/AppData/Local/exact_nvim/exact_lsp/lua_ls.lua.tmpl
+++ b/AppData/Local/exact_nvim/exact_lsp/lua_ls.lua.tmpl
@@ -1,0 +1,1 @@
+{{- template "nvim/lsp/lua_ls.lua" . -}}

--- a/dot_config/exact_nvim/exact_lsp/lua_ls.lua.tmpl
+++ b/dot_config/exact_nvim/exact_lsp/lua_ls.lua.tmpl
@@ -1,0 +1,1 @@
+{{- template "nvim/lsp/lua_ls.lua" . -}}


### PR DESCRIPTION
lua_ls treats config as plain Lua, so `vim` and plugin APIs have no
hover. Point the workspace library at VIMRUNTIME plus vim.pack.get()
plugin paths. get() reads plugins off disk rather than the runtimepath,
so lazily-added ones are included too.

Closes #547
