### PR TITLE
feat(bashrc): add aqua-prune to wipe the aqua root directory

### DIFF
--- a/dot_bashrc
+++ b/dot_bashrc
@@ -170,3 +170,8 @@ chezmoi-cd() {
 zk-cd() {
     cd "$ZK_NOTEBOOK_DIR"
 }
+
+# aqua はたまにしか使わないため、root-dir ごと消してクリーンな状態に戻す
+aqua-prune() {
+    rm -rf "$(aqua root-dir)"
+}


### PR DESCRIPTION
aqua is used only occasionally, so leftover packages accumulate in
AQUA_ROOT_DIR without being noticed.
