### PR TITLE
chore(chezmoiignore): exclude xfce4 pointers.xml from management

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -18,6 +18,7 @@ Makefile
 
 {{- if eq .chezmoi.os "linux" }}
 .config/xfce4/xfconf/xfce-perchannel-xml/displays.xml
+.config/xfce4/xfconf/xfce-perchannel-xml/pointers.xml
 .config/xfce4/desktop
 .config/nvim/nvim-pack-lock.json
 .config/fcitx5/conf/cached_layouts


### PR DESCRIPTION
Mouse settings depend on per-machine hardware configuration, so they
should not be tracked in dotfiles.
