### PR TITLE
chore(claude): set default effort level to medium

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -49,6 +49,7 @@
   "language": "japanese",
   "feedbackSurveyRate": 0,
   "alwaysThinkingEnabled": true,
+  "effortLevel": "medium",
   "fastModePerSessionOptIn": true,
   "autoUpdatesChannel": "latest",
   "tui": "default",


### PR DESCRIPTION
High effort leads to more tool calls and changes than requested. Raise it
per session with /effort when a task needs deeper reasoning.
