### PR TITLE
docs(adr): record why mise cannot replace chezmoi prefixes

### DIFF
--- a/docs/adr/0002-defer-mise-bootstrap-migration.md
+++ b/docs/adr/0002-defer-mise-bootstrap-migration.md
@@ -12,6 +12,12 @@ chezmoi から `mise bootstrap` への移行を検討したが、次の要件を
 - Windows のシステムパッケージを `[bootstrap.packages]` で管理できない
 - Windows では mise タスクを使用しない
 
+2026 年 8 月時点の mise ドキュメント（https://mise.jdx.dev/dotfiles.html 、https://mise.jdx.dev/templates.html ）で、削除とパーミッションの扱いを再確認した。
+
+- `symlink-each` は mise 自身が作成したシンボリックリンクだけを prune し、管理外のファイルは残す。`exact_` の「ディレクトリの中身をソースと完全一致させる」挙動には届かない
+- `[dotfiles]` の `mode` は配置方式（`symlink` / `symlink-each` / `copy` / `template`）を指し、パーミッションを指定するキーはない。`private_` と `executable_` に相当する宣言ができない
+- `symlink` モードならソース側の権限が透過するが、Windows ではシンボリックリンクが copy にフォールバックするため権限が崩れる
+
 ## Decision
 
 現時点では `mise bootstrap` へ移行しない。


### PR DESCRIPTION
The blocker was a single vague line about deletion sync, which was not
enough to re-evaluate against a future mise release.
