### PR TITLE
fix(claude): propagate mise PATH to the Bash tool via BASH_ENV

### DIFF
--- a/docs/adr/0007-use-bash-env-for-claude-code-bash-tool-path.md
+++ b/docs/adr/0007-use-bash-env-for-claude-code-bash-tool-path.md
@@ -1,0 +1,43 @@
+# Claude Code の Bash ツールに PATH 設定を届けるため BASH_ENV を使う
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0006 に従い `CLAUDE_CODE_GIT_BASH_PATH` に MSYS2 の bash.exe を直接指定している。  
+確認したところ、Windows の Claude Code で Bash ツールが起動する bash は非ログイン・非対話シェルだった。  
+`.bashrc` は対話シェルでのみ読み込まれ、Bash ツールが起動する非ログイン・非対話シェルでは読み込まれない。  
+`.bashrc` にある mise の shims、aqua、`~/.local/bin` の PATH 追加もこれに含まれ、  
+Bash ツールには反映されず、`gh` など mise 管理のコマンドが見つからなくなる。
+
+対応策として次を試した。
+
+- `CLAUDE_CODE_GIT_BASH_PATH` をログインシェル起動のラッパーに差し替える
+  - Claude Code が bash と認識せず起動不能になった
+- `settings.json` の `env.PATH` に PATH 文字列を直接書く
+  - 環境が変わるたびに手動更新が必要になる
+- bash 標準の `BASH_ENV`（非対話シェルの起動時に読み込むファイルを指定する仕組み）を使う
+  - `.bashrc` の対話限定の制約と無関係に動作する
+
+`BASH_ENV` の指定場所には2通りある。
+
+- `settings.json` の `env.BASH_ENV` に明示する
+- `.bashrc` で `export` し、WezTerm の対話シェルからの環境変数の継承に委ねる
+    - この方法は WezTerm 経由以外の起動では機能しない
+
+Claude Code の起動経路は WezTerm 経由のみである。
+
+## Decision
+
+PATH の構築を含む環境変数の定義を `.bashrc` から `~/.bash_env` に切り出す。  
+`.bashrc` は `export BASH_ENV=~/.bash_env` と `source "$BASH_ENV"` の2行のみとする。  
+`settings.json` には `BASH_ENV` を設定しない。
+
+## Consequences
+
+- `.bash_env` に定義が一本化され、対話・非対話どちらのシェルも同じロジックを共有する
+- `settings.json` に理由の読み取りにくい設定を増やさずに済む
+- Claude Code を WezTerm 以外の経路から起動すると継承チェーンが働かず、mise 等の PATH が Bash ツールに届かない
+- 環境変数は WezTerm の対話シェル → claude.exe → Bash ツールの bash という3段階の継承を経て届くため、挙動の把握にはこの経路全体の理解が必要になる

--- a/dot_bash_env
+++ b/dot_bash_env
@@ -1,0 +1,13 @@
+export EDITOR=nvim
+export LANG=ja_JP.UTF-8
+export GH_PAGER=delta
+export GLAB_PAGER=delta
+export ZK_NOTEBOOK_DIR=~/git/my-zk
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+# 以下は`PATH="$HOME/.local/share/mise/shims:$PATH"`と同義
+# Windowsのmiseはshimsしかサポートしていない
+eval "$(mise activate bash --shims)"
+# aqua があるときだけ PATH に追加
+if command -v aqua >/dev/null 2>&1; then
+  export PATH="$(aqua root-dir)/bin:$PATH"
+fi

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -149,19 +149,8 @@ if ! shopt -oq posix; then
 fi
 
 # 環境変数
-export EDITOR=nvim
-export LANG=ja_JP.UTF-8
-export GH_PAGER=delta
-export GLAB_PAGER=delta
-export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
-export ZK_NOTEBOOK_DIR=~/git/my-zk
-# 以下は`PATH="$HOME/.local/share/mise/shims:$PATH"`と同義
-# Windowsのmiseはshimsしかサポートしていない
-eval "$(mise activate bash --shims)"
-# aqua があるときだけ PATH に追加
-if command -v aqua >/dev/null 2>&1; then
-  export PATH="$(aqua root-dir)/bin:$PATH"
-fi
+export BASH_ENV=~/.bash_env
+source "$BASH_ENV"
 
 # chezmoi cd がシェルを起動してしまう問題を回避
 chezmoi-cd() {

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -2,7 +2,7 @@
   "respectGitignore": true,
   "env": {
     "CLAUDE_CODE_SUBAGENT_MODEL": "sonnet",
-    "CLAUDE_CODE_GIT_BASH_PATH": "C:\\msys64\\usr\\bin\\bash.exe",
+    "CLAUDE_CODE_GIT_BASH_PATH": "C:/msys64/usr/bin/bash.exe",
     "CLAUDE_CODE_USE_POWERSHELL_TOOL": "0"
   },
   "attribution": {


### PR DESCRIPTION
Claude Code's Bash tool runs a non-login, non-interactive bash, so
.bashrc's mise/PATH setup never ran and mise-managed commands were
invisible to it.
