### PR TITLE
feat(dotfiles): add ghq and fzf for repository navigation

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,9 +1,10 @@
 [data]
 gitUserName = "{{ promptString "Git user name" }}"
 gitEmail = "{{ promptString "Git email address" }}"
-gitSigningkey = "{{ promptString "Git signing key (leave empty to skip)" }}"
+gitSigningkey = "{{ promptString "Git signing public key path, e.g. ~/.ssh/id_ed25519.pub or C:/Users/you/.ssh/id_ed25519.pub; use / as separator (leave empty to skip)" }}"
 gitEnableCredential = {{ promptBool "Enable credential provider (generic)" }}
 miseMinimal = {{ promptBool "Minimal mise setup" }}
+ghqRoot = "{{ promptString "Additional ghq root directory, e.g. ~/myprojects or C:/Users/you/myprojects; use / as separator (leave empty to skip)" }}"
 
 [diff]
     pager = "delta"

--- a/dot_bash_env.tmpl
+++ b/dot_bash_env.tmpl
@@ -7,7 +7,6 @@ export EDITOR=nvim
 export LANG=ja_JP.UTF-8
 export GH_PAGER=delta
 export GLAB_PAGER=delta
-export ZK_NOTEBOOK_DIR=~/git/my-zk
 export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 # 以下は`PATH="$HOME/.local/share/mise/shims:$PATH"`と同義
 # Windowsのmiseはshimsしかサポートしていない
@@ -15,6 +14,13 @@ eval "$(mise activate bash --shims)"
 # aqua があるときだけ PATH に追加
 if command -v aqua >/dev/null 2>&1; then
   export PATH="$(aqua root-dir)/bin:$PATH"
+fi
+
+# my-zk を ghq 管理下から特定し、zk のノートブックディレクトリにする（未 clone なら空のまま）
+if command -v ghq >/dev/null 2>&1; then
+  _zk_repo=$(ghq list --exact --full-path my-zk | head -n1)
+  [ -n "$_zk_repo" ] && export ZK_NOTEBOOK_DIR=$_zk_repo
+  unset _zk_repo
 fi
 
 export BASH_ENV=$_bash_env_path

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -152,12 +152,11 @@ fi
 export BASH_ENV=~/.bash_env
 source "$BASH_ENV"
 
-# chezmoi cd がシェルを起動してしまう問題を回避
-chezmoi-cd() {
-    cd $(chezmoi source-path)
-}
-zk-cd() {
-    cd "$ZK_NOTEBOOK_DIR"
+# ghq と fzf でリポジトリを選択して cd する
+ghq-cd() {
+    local repo
+    repo=$(ghq list --full-path | fzf) || return
+    cd "$repo" || return
 }
 
 # aqua はたまにしか使わないため、root-dir ごと消してクリーンな状態に戻す

--- a/dot_config/exact_git/config.tmpl
+++ b/dot_config/exact_git/config.tmpl
@@ -16,6 +16,12 @@
     line-numbers = true # 行番号を表示
 [merge]
     conflictStyle = zdiff3 # 競合時に元のテキストも表示
+[ghq]
+    root = {{ .chezmoi.sourceDir }} # chezmoi のソースディレクトリを優先的に検索
+{{- if ne .ghqRoot "" }}
+    root = {{ .ghqRoot }} # ユーザー定義の追加ルート
+{{- end }}
+    root = ~/ghq # ghq のデフォルトルート（新規 clone 先はこれが優先される）
 [user]
     name = {{ .gitUserName }} # Git のユーザー名
     email = {{ .gitEmail }} # Git のメールアドレス

--- a/dot_config/exact_mise/mise.toml.tmpl
+++ b/dot_config/exact_mise/mise.toml.tmpl
@@ -7,6 +7,8 @@
 "aqua:jdx/usage" = "latest"
 "aqua:openai/codex" = "latest"
 "gitlab:gitlab-org/cli" = "latest"
+"aqua:x-motemen/ghq" = "latest"
+"aqua:junegunn/fzf" = "latest"
 
 {{- if not .miseMinimal }}
 "core:go" = "latest"


### PR DESCRIPTION
Add ghq and fzf via mise, search chezmoi's source dir before ghq's
default root, and replace chezmoi-cd/zk-cd with a single ghq-cd.
Also clarify the git signing key prompt to ask for a path.
