### PR TITLE
feat(git): add git-resign command to re-sign recent commits

### DIFF
--- a/dot_local/exact_bin/executable_git-resign
+++ b/dot_local/exact_bin/executable_git-resign
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+if [ "${1:-}" = "--help" ]; then
+  cat <<'EOF'
+Usage: git resign <n>
+
+Re-sign the last <n> commits (e.g. after rotating the signing key).
+Each commit is amended in place with a fresh signature via a
+non-interactive rebase, keeping messages, dates, and content untouched.
+EOF
+  exit 0
+fi
+
+case "${1:-}" in
+  ''|*[!0-9]*|0)
+    printf 'error: <n> must be a positive integer\n' >&2
+    exit 1
+    ;;
+esac
+
+git rebase --exec 'git commit --amend --no-edit -S' "HEAD~$1"


### PR DESCRIPTION
Wraps a non-interactive rebase with commit --amend -S so the last
N commits can be re-signed, e.g. after rotating the signing key.
