### PR TITLE
feat(nvim): replace mini.pick with fzf-lua

### DIFF
--- a/.chezmoitemplates/nvim/lua/keymaps.lua
+++ b/.chezmoitemplates/nvim/lua/keymaps.lua
@@ -19,7 +19,7 @@ else
 	-- LSPキーマップ
 	vim.keymap.set("n", "gd", vim.lsp.buf.definition, { desc = "Goto Definition" })
 	vim.keymap.set("n", "gr", function()
-		require("mini.extra").pickers.lsp({ scope = "references" })
+		require("fzf-lua").lsp_references()
 	end, { desc = "References" })
 	vim.keymap.set("n", "K", function()
 		vim.lsp.buf.hover({ border = "single" })
@@ -30,38 +30,25 @@ else
 		require("floatmemo").toggle()
 	end, { desc = "Toggle floatmemo" })
 
-	-- gitリポジトリかどうかを判定
-	local function is_git_repo()
-		local result = vim.system({ "git", "rev-parse", "--git-dir" }, { text = true }):wait()
-		return result.code == 0
-	end
-
-	-- mini.pickのファイル検索を起動（gitリポジトリならgit、そうでないならrg）
+	-- fzf-luaのファイル検索を起動
 	vim.keymap.set("n", "<leader>p", function()
-		local tool = is_git_repo() and "git" or "rg"
-		require("mini.pick").builtin.files({ tool = tool })
-	end, { desc = "Pick files (S-Tab: show keymaps)" })
+		require("fzf-lua").files()
+	end, { desc = "Pick files" })
 
-	-- mini.pickの横断したあいまい検索を起動（gitリポジトリならgit、そうでないならrg）
+	-- fzf-luaの横断したあいまい検索（live grep）を起動
 	vim.keymap.set("n", "<leader>f", function()
-		local tool = is_git_repo() and "git" or "rg"
-		require("mini.pick").builtin.grep_live({ tool = tool })
-	end, { desc = "Live grep (C-o: glob, S-Tab: show keymaps)" })
+		require("fzf-lua").live_grep()
+	end, { desc = "Live grep" })
 
-	-- 最近訪問したファイルを起動
-	vim.keymap.set("n", "<leader>v", function()
-		require("mini.extra").pickers.visit_paths()
-	end, { desc = "Pick visited files (S-Tab: show keymaps)" })
-
-	-- mini.pickのヘルプ検索を起動
+	-- fzf-luaのヘルプ検索を起動
 	vim.keymap.set("n", "<leader>h", function()
-		require("mini.pick").builtin.help()
-	end, { desc = "Help (S-Tab: show keymaps)" })
+		require("fzf-lua").helptags()
+	end, { desc = "Help" })
 
-	-- mini.pickの最後のpickerを再開
+	-- fzf-luaの最後のpickerを再開
 	vim.keymap.set("n", "<leader>r", function()
-		require("mini.pick").builtin.resume()
-	end, { desc = "Resume picker (S-Tab: show keymaps)" })
+		require("fzf-lua").resume()
+	end, { desc = "Resume picker" })
 
 	-- zk-nvim
 	vim.keymap.set("n", "<leader>zn", function()
@@ -155,15 +142,7 @@ local function get_mini_files_mappings()
 	}
 end
 
--- mini.pick用のキーマップ設定を返す関数
-local function get_mini_pick_mappings()
-	return {
-		choose_marked = "<C-q>",
-	}
-end
-
 return {
 	get_mini_align_mappings = get_mini_align_mappings,
 	get_mini_files_mappings = get_mini_files_mappings,
-	get_mini_pick_mappings = get_mini_pick_mappings,
 }

--- a/.chezmoitemplates/nvim/lua/lang.lua
+++ b/.chezmoitemplates/nvim/lua/lang.lua
@@ -65,19 +65,19 @@ require("plugins").later(function()
 		-- LSP操作のテーブル定義
 		M.lsp_actions = {
 			["type-def"] = function()
-				require("mini.extra").pickers.lsp({ scope = "type_definition" })
+				require("fzf-lua").lsp_typedefs()
 			end,
 			["impl"] = function()
-				require("mini.extra").pickers.lsp({ scope = "implementation" })
+				require("fzf-lua").lsp_implementations()
 			end,
 			["code-action"] = vim.lsp.buf.code_action,
 			["rename"] = vim.lsp.buf.rename,
 			["diag"] = function()
-				require("mini.extra").pickers.diagnostic({ scope = "current" })
+				require("fzf-lua").diagnostics_document()
 			end,
 			["format"] = conform.format,
 			["symbol"] = function()
-				require("mini.extra").pickers.lsp({ scope = "document_symbol" })
+				require("fzf-lua").lsp_document_symbols()
 			end,
 		}
 	end

--- a/.chezmoitemplates/nvim/lua/plugins.lua
+++ b/.chezmoitemplates/nvim/lua/plugins.lua
@@ -48,16 +48,6 @@ if not vim.g.vscode then
 		require("mini.files").setup({
 			mappings = require("keymaps").get_mini_files_mappings(),
 		}) -- ファイラー
-		require("mini.pick").setup({
-			mappings = require("keymaps").get_mini_pick_mappings(),
-			window = {
-				config = function()
-					return {
-						width = math.floor((vim.o.columns - 8) / 2),
-					}
-				end,
-			},
-		}) -- ピッカー
 		local animate = require("mini.animate") -- アニメーション
 		animate.setup({
 			cursor = {
@@ -88,7 +78,6 @@ if not vim.g.vscode then
 		require("mini.completion").setup() -- 補完
 		require("mini.cmdline").setup() -- コマンドライン
 		require("mini.trailspace").setup() -- 末尾の空白をハイライト
-		require("mini.visits").setup() -- ファイルアクセス履歴追跡
 		require("mini.git").setup() -- `:Git`コマンドを追加
 		require("mini.pairs").setup({
 			mappings = {
@@ -111,7 +100,6 @@ if not vim.g.vscode then
 				},
 			},
 		}) -- スニペット
-		require("mini.extra").setup() -- 追加
 
 		require("mini.clue").setup({
 			-- リーダーキーのみトリガー
@@ -140,19 +128,29 @@ if not vim.g.vscode then
 			end),
 		})
 
-		-- プラグイン一括追加: 自作, LSP, フォーマッタ
+		-- プラグイン一括追加: 自作, LSP, フォーマッタ, ピッカー
 		add({
-			"https://github.com/sh1Nome/mini-pick-preview.nvim",
 			"https://github.com/sh1Nome/floatmemo.nvim",
 			"https://github.com/sh1Nome/floatcli.nvim",
 			"https://github.com/neovim/nvim-lspconfig",
 			"https://github.com/stevearc/conform.nvim",
 			"https://github.com/zk-org/zk-nvim",
 			"https://github.com/itchyny/vim-qfedit",
+			"https://github.com/ibhagwan/fzf-lua",
 		})
 
-		-- mini-pick-preview
-		require("mini-pick-preview").setup()
+		-- fzf-lua
+		require("fzf-lua").setup({
+			winopts = {
+				border = "single",
+				preview = { border = "single" },
+			},
+			grep = {
+				hidden = true,
+				no_ignore = false,
+			},
+		}) -- ピッカー
+		require("fzf-lua").register_ui_select() -- vim.ui.select()をfzf-luaに置き換え
 
 		-- floatmemo
 		require("floatmemo").setup({
@@ -174,7 +172,7 @@ if not vim.g.vscode then
 
 		-- zk
 		require("zk").setup({
-			picker = "minipick",
+			picker = "fzf_lua",
 		})
 	end)
 end


### PR DESCRIPTION
fzf was already provisioned via mise, and mini.pick's live_grep glob
filter was hard to clear mid-search while its preview relied on a
separate custom plugin. fzf-lua bundles preview natively and supports
inline `-- glob` filtering that's easy to edit, so it replaces
mini.pick, mini.extra, and mini-pick-preview.nvim.
